### PR TITLE
Simplify data model and add method for retrieving notes for a release.

### DIFF
--- a/rna/admin.py
+++ b/rna/admin.py
@@ -7,7 +7,16 @@ from django.contrib import admin
 from . import models
 
 
-admin.site.register(models.Channel)
-admin.site.register(models.Product)
-admin.site.register(models.Tag)
-admin.site.register(models.Note)
+class NoteAdmin(admin.ModelAdmin):
+    list_display = ('bug', 'tag', 'html')
+    list_display_links = ('html',)
+    filter_horizontal = ('releases',)
+
+
+class ReleaseAdmin(admin.ModelAdmin):
+    list_display = ('version', 'product', 'channel', 'is_public',
+                    'release_date', 'text')
+
+
+admin.site.register(models.Note, NoteAdmin)
+admin.site.register(models.Release, ReleaseAdmin)

--- a/rna/clients.py
+++ b/rna/clients.py
@@ -90,6 +90,16 @@ class RestModelClient(RestClient):
                 url = data.pop(field.name, None)
                 if url:
                     data[field.name] = self.hypermodel(url, field.rel.to, save)
+
+        # ManyToManyFields
+        for field in serializer.Meta.model._meta.many_to_many:
+            urls = data.pop(field.name, None)
+            if urls:
+                data[field.name] = [
+                    self.hypermodel(url, field.rel.to, save)
+                    for url in urls
+                ]
+
         instance = serializer.restore_object(data)
         if save:
             serializer.save_object(instance, modified=modified)
@@ -134,11 +144,9 @@ class RestModelClient(RestClient):
 
 class RNAModelClient(RestModelClient):
     model_map = {
-        'channels': models.Channel,
         'notes': models.Note,
-        'products': models.Product,
         'releases': models.Release,
-        'tags': models.Tag}
+    }
 
 
 class LegacyRNAModelClient(RNAModelClient):

--- a/rna/migrations/0003_auto__add_field_note_fixed_in_release__add_field_note_tag_num__add_fie.py
+++ b/rna/migrations/0003_auto__add_field_note_fixed_in_release__add_field_note_tag_num__add_fie.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Note.fixed_in_release'
+        db.add_column('rna_note', 'fixed_in_release',
+                      self.gf('django.db.models.fields.related.ForeignKey')(related_name='fixed_note_set', null=True, to=orm['rna.Release']),
+                      keep_default=False)
+
+        # Adding field 'Note.tag_num'
+        db.add_column('rna_note', 'tag_num',
+                      self.gf('django.db.models.fields.IntegerField')(null=True),
+                      keep_default=False)
+
+        # Adding M2M table for field releases on 'Note'
+        m2m_table_name = db.shorten_name('rna_note_releases')
+        db.create_table(m2m_table_name, (
+            ('id', models.AutoField(verbose_name='ID', primary_key=True, auto_created=True)),
+            ('note', models.ForeignKey(orm['rna.note'], null=False)),
+            ('release', models.ForeignKey(orm['rna.release'], null=False))
+        ))
+        db.create_unique(m2m_table_name, ['note_id', 'release_id'])
+
+        # Adding field 'Release.product_num'
+        db.add_column('rna_release', 'product_num',
+                      self.gf('django.db.models.fields.IntegerField')(default=0),
+                      keep_default=False)
+
+        # Adding field 'Release.channel_num'
+        db.add_column('rna_release', 'channel_num',
+                      self.gf('django.db.models.fields.IntegerField')(default=0),
+                      keep_default=False)
+
+        # Adding field 'Release.version_str'
+        db.add_column('rna_release', 'version_str',
+                      self.gf('django.db.models.fields.CharField')(default='1.0', max_length=255),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Note.fixed_in_release'
+        db.delete_column('rna_note', 'fixed_in_release_id')
+
+        # Deleting field 'Note.tag_num'
+        db.delete_column('rna_note', 'tag_num')
+
+        # Removing M2M table for field releases on 'Note'
+        db.delete_table(db.shorten_name('rna_note_releases'))
+
+        # Deleting field 'Release.product_num'
+        db.delete_column('rna_release', 'product_num')
+
+        # Deleting field 'Release.channel_num'
+        db.delete_column('rna_release', 'channel_num')
+
+        # Deleting field 'Release.version_str'
+        db.delete_column('rna_release', 'version_str')
+
+
+    models = {
+        'rna.channel': {
+            'Meta': {'object_name': 'Channel'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'rna.note': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Note'},
+            'bug': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'first_channel': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'first_channel_notes'", 'null': 'True', 'to': "orm['rna.Channel']"}),
+            'first_version': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'fixed_in_channel': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'fixed_in_channel_notes'", 'null': 'True', 'to': "orm['rna.Channel']"}),
+            'fixed_in_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fixed_note_set'", 'null': 'True', 'to': "orm['rna.Release']"}),
+            'fixed_in_subversion': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'fixed_in_version': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rna.Product']", 'null': 'True', 'blank': 'True'}),
+            'releases': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rna.Release']", 'symmetrical': 'False'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rna.Tag']", 'null': 'True', 'blank': 'True'}),
+            'tag_num': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        'rna.product': {
+            'Meta': {'object_name': 'Product'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        'rna.release': {
+            'Meta': {'object_name': 'Release'},
+            'channel': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rna.Channel']"}),
+            'channel_num': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rna.Product']"}),
+            'product_num': ('django.db.models.fields.IntegerField', [], {}),
+            'release_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'sub_version': ('django.db.models.fields.IntegerField', [], {}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {}),
+            'version_str': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'rna.tag': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Tag'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        }
+    }
+
+    complete_apps = ['rna']

--- a/rna/migrations/0004_migrate_old_data.py
+++ b/rna/migrations/0004_migrate_old_data.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        PRODUCTS = {
+            'FIREFOX': 0,
+            'FENNEC': 1,
+            'ESR': 2,
+        }
+
+        CHANNELS = {
+            'NIGHTLY': 0,
+            'AURORA': 1,
+            'BETA': 2,
+            'RELEASE': 3,
+        }
+
+        TAGS = {
+            'NEW': 0,
+            'CHANGED': 1,
+            'HTML5': 2,
+            'FIXED': 3,
+            'DEVELOPER': 4,
+        }
+
+        # Hard-coded product IDs. Sadface.
+        DB_PRODUCTS = {
+            1: PRODUCTS['FIREFOX'],
+            2: PRODUCTS['FENNEC'],
+            3: PRODUCTS['ESR'],
+        }
+
+        for release in orm.Release.objects.all():
+            release.version_str = '{0}.0.{1}'.format(release.version, release.sub_version)
+
+            if release.channel.name == 'ESR':
+                release.product_num = PRODUCTS['ESR']
+                release.channel_num = CHANNELS['RELEASE']
+            else:
+                release.product_num = DB_PRODUCTS[release.product.id]
+                release.channel_num = CHANNELS[release.channel.name.upper()]
+            release.save()
+
+        for note in orm.Note.objects.all():
+            if note.tag:
+                note.tag_num = TAGS[note.tag.text.upper()]
+
+            # Migrate to fixed_in_release
+            if note.fixed_in_version:
+                version = '{0}.0.{1}'.format(note.fixed_in_version, note.fixed_in_subversion or 0)
+                filters = {'version_str': version}
+
+                if note.fixed_in_channel:
+                    if note.fixed_in_channel.name.upper() == 'ESR':
+                        filters['product_num'] = PRODUCTS['ESR']
+                        filters['channel_num'] = CHANNELS['RELEASE']
+                    else:
+                        filters['channel_num'] = CHANNELS[note.fixed_in_channel.name.upper()]
+
+                        if note.product:
+                            filters['product_num'] = DB_PRODUCTS[note.product.id]
+
+                try:
+                    note.fixed_in_release = orm.Release.objects.get(**filters)
+                except (orm.Release.DoesNotExist, orm.Release.MultipleObjectsReturned):
+                    note.fixed_in_release = None
+
+            note.save()
+
+    def backwards(self, orm):
+        """No going backwards, as this migration is going to be deleted someday anyway."""
+
+
+    models = {
+        'rna.channel': {
+            'Meta': {'object_name': 'Channel'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'rna.note': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Note'},
+            'bug': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'first_channel': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'first_channel_notes'", 'null': 'True', 'to': "orm['rna.Channel']"}),
+            'first_version': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'fixed_in_channel': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'fixed_in_channel_notes'", 'null': 'True', 'to': "orm['rna.Channel']"}),
+            'fixed_in_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fixed_note_set'", 'null': 'True', 'to': "orm['rna.Release']"}),
+            'fixed_in_subversion': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'fixed_in_version': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rna.Product']", 'null': 'True', 'blank': 'True'}),
+            'releases': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rna.Release']", 'symmetrical': 'False'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rna.Tag']", 'null': 'True', 'blank': 'True'}),
+            'tag_num': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        'rna.product': {
+            'Meta': {'object_name': 'Product'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        'rna.release': {
+            'Meta': {'object_name': 'Release'},
+            'channel': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rna.Channel']"}),
+            'channel_num': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['rna.Product']"}),
+            'product_num': ('django.db.models.fields.IntegerField', [], {}),
+            'release_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'sub_version': ('django.db.models.fields.IntegerField', [], {}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'version': ('django.db.models.fields.IntegerField', [], {}),
+            'version_str': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'rna.tag': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Tag'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        }
+    }
+
+    complete_apps = ['rna']
+    symmetrical = True

--- a/rna/migrations/0005_auto__del_field_note_first_version__del_field_note_first_channel__del_.py
+++ b/rna/migrations/0005_auto__del_field_note_first_version__del_field_note_first_channel__del_.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting field 'Note.first_version'
+        db.delete_column('rna_note', 'first_version')
+
+        # Deleting field 'Note.first_channel'
+        db.delete_column('rna_note', 'first_channel_id')
+
+        # Deleting field 'Note.fixed_in_version'
+        db.delete_column('rna_note', 'fixed_in_version')
+
+        # Deleting field 'Note.fixed_in_subversion'
+        db.delete_column('rna_note', 'fixed_in_subversion')
+
+        # Deleting field 'Note.product'
+        db.delete_column('rna_note', 'product_id')
+
+        # Deleting field 'Note.fixed_in_channel'
+        db.delete_column('rna_note', 'fixed_in_channel_id')
+
+        # Deleting field 'Note.tag_id'
+        db.delete_column('rna_note', 'tag_id')
+
+        # Renaming column for 'Note.tag_num'.
+        db.rename_column('rna_note', 'tag_num', 'tag')
+
+        # Deleting field 'Release.sub_version'
+        db.delete_column('rna_release', 'sub_version')
+
+        # Deleting field 'Release.channel_id'
+        db.delete_column('rna_release', 'channel_id')
+
+        # Deleting field 'Release.product_num'
+        db.delete_column('rna_release', 'product_id')
+
+        # Deleting field 'Release.version_str'
+        db.delete_column('rna_release', 'version')
+
+        # Renaming column for 'Release.product_str'.
+        db.rename_column('rna_release', 'product_num', 'product')
+
+        # Renaming column for 'Release.version_str'.
+        db.rename_column('rna_release', 'version_str', 'version')
+
+        # Renaming column for 'Release.channel_num'.
+        db.rename_column('rna_release', 'channel_num', 'channel')
+
+
+    def backwards(self, orm):
+        raise RuntimeError("Cannot reverse this migration.")
+
+    models = {
+        'rna.channel': {
+            'Meta': {'object_name': 'Channel'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'rna.note': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Note'},
+            'bug': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'fixed_in_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fixed_note_set'", 'null': 'True', 'to': "orm['rna.Release']"}),
+            'html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'releases': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rna.Release']", 'symmetrical': 'False'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tag': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        'rna.product': {
+            'Meta': {'object_name': 'Product'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'})
+        },
+        'rna.release': {
+            'Meta': {'object_name': 'Release'},
+            'channel': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.IntegerField', [], {}),
+            'release_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        'rna.tag': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Tag'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'text': ('django.db.models.fields.TextField', [], {})
+        }
+    }
+
+    complete_apps = ['rna']

--- a/rna/migrations/0006_auto__del_tag__del_channel__del_product.py
+++ b/rna/migrations/0006_auto__del_tag__del_channel__del_product.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Deleting model 'Tag'
+        db.delete_table('rna_tag')
+
+        # Deleting model 'Channel'
+        db.delete_table('rna_channel')
+
+        # Deleting model 'Product'
+        db.delete_table('rna_product')
+
+
+    def backwards(self, orm):
+        # Adding model 'Tag'
+        db.create_table('rna_tag', (
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, blank=True)),
+            ('text', self.gf('django.db.models.fields.TextField')()),
+            ('modified', self.gf('django.db.models.fields.DateTimeField')(blank=True, db_index=True)),
+            ('sort_num', self.gf('django.db.models.fields.IntegerField')(null=True, blank=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('rna', ['Tag'])
+
+        # Adding model 'Channel'
+        db.create_table('rna_channel', (
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, unique=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('modified', self.gf('django.db.models.fields.DateTimeField')(blank=True, db_index=True)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, blank=True)),
+        ))
+        db.send_create_signal('rna', ['Channel'])
+
+        # Adding model 'Product'
+        db.create_table('rna_product', (
+            ('name', self.gf('django.db.models.fields.CharField')(max_length=255, unique=True)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, blank=True)),
+            ('text', self.gf('django.db.models.fields.TextField')(blank=True)),
+            ('modified', self.gf('django.db.models.fields.DateTimeField')(blank=True, db_index=True)),
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+        ))
+        db.send_create_signal('rna', ['Product'])
+
+
+    models = {
+        'rna.note': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Note'},
+            'bug': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'fixed_in_release': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'fixed_note_set'", 'null': 'True', 'to': "orm['rna.Release']"}),
+            'html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'releases': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rna.Release']", 'symmetrical': 'False'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tag': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        'rna.release': {
+            'Meta': {'object_name': 'Release'},
+            'channel': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.IntegerField', [], {}),
+            'release_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['rna']

--- a/rna/migrations/0007_auto__add_field_release_is_public.py
+++ b/rna/migrations/0007_auto__add_field_release_is_public.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Release.is_public'
+        db.add_column('rna_release', 'is_public',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Release.is_public'
+        db.delete_column('rna_release', 'is_public')
+
+
+    models = {
+        'rna.note': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Note'},
+            'bug': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'fixed_in_release': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'fixed_note_set'", 'null': 'True', 'to': "orm['rna.Release']"}),
+            'html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'releases': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rna.Release']", 'symmetrical': 'False', 'blank': 'True'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tag': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        'rna.release': {
+            'Meta': {'ordering': "('product', '-version', 'channel')", 'object_name': 'Release'},
+            'channel': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.IntegerField', [], {}),
+            'release_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['rna']

--- a/rna/migrations/0008_auto__add_field_note_is_known_issue.py
+++ b/rna/migrations/0008_auto__add_field_note_is_known_issue.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Note.is_known_issue'
+        db.add_column('rna_note', 'is_known_issue',
+                      self.gf('django.db.models.fields.BooleanField')(default=False),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Note.is_known_issue'
+        db.delete_column('rna_note', 'is_known_issue')
+
+
+    models = {
+        'rna.note': {
+            'Meta': {'ordering': "('sort_num',)", 'object_name': 'Note'},
+            'bug': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'fixed_in_release': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'fixed_note_set'", 'null': 'True', 'to': "orm['rna.Release']"}),
+            'html': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_known_issue': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'releases': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['rna.Release']", 'symmetrical': 'False', 'blank': 'True'}),
+            'sort_num': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'tag': ('django.db.models.fields.IntegerField', [], {'null': 'True'})
+        },
+        'rna.release': {
+            'Meta': {'ordering': "('product', '-version', 'channel')", 'object_name': 'Release'},
+            'channel': ('django.db.models.fields.IntegerField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'blank': 'True'}),
+            'product': ('django.db.models.fields.IntegerField', [], {}),
+            'release_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'text': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'version': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        }
+    }
+
+    complete_apps = ['rna']

--- a/rna/urls.py
+++ b/rna/urls.py
@@ -8,10 +8,7 @@ from . import views
 
 
 router = routers.DefaultRouter()
-router.register('channels', views.ChannelViewSet)
 router.register('notes', views.NoteViewSet)
-router.register('products', views.ProductViewSet)
 router.register('releases', views.ReleaseViewSet)
-router.register('tags', views.TagViewSet)
 
 urlpatterns = router.urls

--- a/rna/views.py
+++ b/rna/views.py
@@ -7,18 +7,6 @@ from rest_framework.viewsets import ModelViewSet
 from . import models
 
 
-class ChannelViewSet(ModelViewSet):
-    model = models.Channel
-
-
-class ProductViewSet(ModelViewSet):
-    model = models.Product
-
-
-class TagViewSet(ModelViewSet):
-    model = models.Tag
-
-
 class NoteViewSet(ModelViewSet):
     model = models.Note
 


### PR DESCRIPTION
- Removes the Product, Channel, and Tag models and replaces them with
  IntegerFields with choices.
- Store version number on Release only, as a string.
- Instead of using weird math to figure out what range of releases a
  note should appear on, use an m2m relationship to explicitly list it.
- Add method to Release for retrieving notes for that release.
- Update clients to support m2m relations.

Contains an excessive amount of migrations because we're going to remove
them soon anyway, so it's no big deal.
