### PR TITLE
Add helper methods to Release for bug 965012

### DIFF
--- a/rna/models.py
+++ b/rna/models.py
@@ -50,11 +50,13 @@ class Release(TimeStampedModel):
         channel and major version with the highest minor version,
         or None if no such releases exist
         """
-        return (
-            self._default_manager.filter(
-                version__startswith=self.version.split('.')[0] + '.',
-                channel=self.channel, product=product).order_by('-version')[:1]
-            or [None])[0]
+        releases = self._default_manager.filter(
+            version__startswith=self.version.split('.')[0] + '.',
+            channel=self.channel, product=product).order_by('-version')
+        if releases:
+            return sorted(
+                releases, reverse=True,
+                key=lambda r: len(r.version.split('.')))[0]
 
     def equivalent_android_release(self):
         if self.product == 'Firefox':

--- a/rna/tests.py
+++ b/rna/tests.py
@@ -107,8 +107,10 @@ class ReleaseTest(TestCase):
         release = models.Release(version='42.0', channel='Release')
         release._default_manager = Mock()
         mock_order_by = release._default_manager.filter.return_value.order_by
-        mock_order_by.return_value = ['mock release']
-        eq_(release.equivalent_release_for_product('Firefox'), 'mock release')
+        mock_order_by.return_value = [
+            models.Release(version='42.0'), models.Release(version='42.0.1')]
+        eq_(release.equivalent_release_for_product('Firefox').version,
+            '42.0.1')
         release._default_manager.filter.assert_called_once_with(
             version__startswith='42.', channel='Release', product='Firefox')
         mock_order_by.assert_called_once_with('-version')


### PR DESCRIPTION
Release.equivalent_android_release() for use on desktop releases
Release.equivalent_desktop_release() for use on android releases
