### PR TITLE
Bug-1297025. Separate system requirements table from Release

### DIFF
--- a/rna/models.py
+++ b/rna/models.py
@@ -27,6 +27,14 @@ class TimeStampedModel(models.Model):
         super(TimeStampedModel, self).save(*args, **kwargs)
 
 
+class SystemRequirements(TimeStampedModel):
+    code_name = models.TextField(blank=False)
+    content = models.TextField()
+
+    def __unicode__(self):
+        return self.code_name
+
+
 class Release(TimeStampedModel):
     CHANNELS = ('Nightly', 'Aurora', 'Beta', 'Release', 'ESR')
     PRODUCTS = ('Firefox', 'Firefox for Android',
@@ -43,7 +51,7 @@ class Release(TimeStampedModel):
     is_public = models.BooleanField(default=False)
     bug_list = models.TextField(blank=True)
     bug_search_url = models.CharField(max_length=2000, blank=True)
-    system_requirements = models.TextField(blank=True)
+    system_requirements = models.ForeignKey(SystemRequirements, on_delete=models.CASCADE)
 
     def major_version(self):
         return self.version.split('.', 1)[0]


### PR DESCRIPTION
Refer to the bug [1297025](https://bugzilla.mozilla.org/show_bug.cgi?id=1297025). System requirements should be managed separately and then linked to the release table.