### PR TITLE
Add JSON export command

### DIFF
--- a/rna/management/commands/export_json.py
+++ b/rna/management/commands/export_json.py
@@ -1,0 +1,34 @@
+from __future__ import print_function, unicode_literals
+
+import json
+import os
+from codecs import open
+from shutil import rmtree
+
+from django.conf import settings
+from django.core.management import BaseCommand
+
+from rna.models import Release
+
+
+if hasattr(settings, 'RNA_JSON_EXPORT_DIR'):
+    OUTPUT_DIR = settings.RNA_JSON_EXPORT_DIR
+else:
+    OUTPUT_DIR = os.path.join(settings.ROOT, 'json_export')
+
+
+def setup():
+    rmtree(OUTPUT_DIR, ignore_errors=True)
+    os.mkdir(OUTPUT_DIR)
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **options):
+        # start fresh
+        setup()
+        releases = Release.objects.all_as_list()
+        for rel in releases:
+            with open(os.path.join(OUTPUT_DIR, '{}.json'.format(rel['slug'])), 'w', encoding='utf-8') as fp:
+                json.dump(rel, fp, indent=2, sort_keys=True)
+
+        print('Exported {} releases'.format(len(releases)))

--- a/rna/management/commands/rnasync.py
+++ b/rna/management/commands/rnasync.py
@@ -25,5 +25,4 @@ class Command(BaseCommand):
         sync_data(url=options['url'],
                   clean=clean,
                   last_modified=None if clean else get_last_modified_date(),
-                  api_token=None,
-                  database=options['database'])
+                  api_token=None)

--- a/rna/urls.py
+++ b/rna/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     url(r'^releases/(?P<pk>\d+)/notes/$', views.NestedNoteView.as_view()),
     url(r'^auth_token/$', views.auth_token),
     url(r'^sync/?$', views.rnasync),
+    url(r'^all-releases\.json$', views.export_json),
 ]

--- a/rna/utils.py
+++ b/rna/utils.py
@@ -1,4 +1,7 @@
+import json
+
 from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponse
 
 from .models import Note, Release
 
@@ -40,3 +43,13 @@ def get_duplicate_product_versions():
                 duplicates[(product, r.version)] = version_ids[product][
                     r.version]
     return duplicates
+
+
+class HttpResponseJSON(HttpResponse):
+    def __init__(self, data, status=None, cors=False):
+        super(HttpResponseJSON, self).__init__(content=json.dumps(data),
+                                               content_type='application/json',
+                                               status=status)
+
+        if cors:
+            self['Access-Control-Allow-Origin'] = '*'

--- a/tests/test_rna.py
+++ b/tests/test_rna.py
@@ -19,14 +19,12 @@ class RnaSyncCommandTests(TestCase):
     def test_call_no_args(self, sync_data_mock):
         call_command('rnasync')
         sync_data_mock.assert_called_with(url='retrovirus', clean=False,
-                                          last_modified=None, api_token=None,
-                                          database='default')
+                                          last_modified=None, api_token=None)
 
     def test_call_with_args(self, sync_data_mock):
         call_command('rnasync', url='megavirus', clean=True)
         sync_data_mock.assert_called_with(url='megavirus', clean=True,
-                                          last_modified=None, api_token=None,
-                                          database='default')
+                                          last_modified=None, api_token=None)
 
 
 class TimeStampedModelTest(TestCase):


### PR DESCRIPTION
Also adds a `/all-releases.json` URL that can be easily read by external scripts ([for example](https://github.com/mozilla/release-notes/blob/master/update_releases.py)).